### PR TITLE
Add go.version support with an enum…

### DIFF
--- a/go-crane-image/go-crane-image.yaml
+++ b/go-crane-image/go-crane-image.yaml
@@ -49,11 +49,15 @@ spec:
         Golang options, such as flags, …
       type: object
       properties:
+        version:
+          type: string
+          enum: ["1.19", "1.20", "1.21", "1.22"]
         GOFLAGS: {type: string}
         GOOS: {type: string}
         GOARCH: {type: string}
         CGO_ENABLED: {type: string}
       default:
+        version: "1.21"
         GOFLAGS: "-v"
         GOOS: ""
         GOARCH: ""


### PR DESCRIPTION
… to list the only go version allowed/supported.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
